### PR TITLE
Change event format because not worked on rasbperry pi3 (32Bit)

### DIFF
--- a/pyPS4Controller/controller.py
+++ b/pyPS4Controller/controller.py
@@ -443,7 +443,7 @@ class Controller(Actions):
             # thus they are blacklisted by default. Feel free to adjust this list to your linking when sub-classing
             self.black_listed_buttons += [6, 7, 8, 11, 12, 13]
         self.event_definition = event_definition if event_definition else Event
-        self.event_format = event_format if event_format else "LhBB"
+        self.event_format = event_format if event_format else "<LhBB"
         self.event_size = struct.calcsize(self.event_format)
         self.event_history = []
 


### PR DESCRIPTION
I had some problems on a Rasbperry Pi3 32bit with the event format. Changing to '<LhBB' helped.