### PR TITLE
Change event definition for x, circle, triangle and square. (Works wi…

### DIFF
--- a/pyPS4Controller/controller.py
+++ b/pyPS4Controller/controller.py
@@ -93,28 +93,28 @@ class Event:
 
     # Square / Triangle / Circle / X Button group #
     def circle_pressed(self):
-        return self.button_id == 2 and self.button_type == 1 and self.value == 1
-
-    def circle_released(self):
-        return self.button_id == 2 and self.button_type == 1 and self.value == 0
-
-    def x_pressed(self):
         return self.button_id == 1 and self.button_type == 1 and self.value == 1
 
-    def x_released(self):
+    def circle_released(self):
         return self.button_id == 1 and self.button_type == 1 and self.value == 0
 
-    def triangle_pressed(self):
-        return self.button_id == 3 and self.button_type == 1 and self.value == 1
-
-    def triangle_released(self):
-        return self.button_id == 3 and self.button_type == 1 and self.value == 0
-
-    def square_pressed(self):
+    def x_pressed(self):
         return self.button_id == 0 and self.button_type == 1 and self.value == 1
 
-    def square_released(self):
+    def x_released(self):
         return self.button_id == 0 and self.button_type == 1 and self.value == 0
+
+    def triangle_pressed(self):
+        return self.button_id == 2 and self.button_type == 1 and self.value == 1
+
+    def triangle_released(self):
+        return self.button_id == 2 and self.button_type == 1 and self.value == 0
+
+    def square_pressed(self):
+        return self.button_id == 3 and self.button_type == 1 and self.value == 1
+
+    def square_released(self):
+        return self.button_id == 3 and self.button_type == 1 and self.value == 0
 
     def options_pressed(self):
         return self.button_id == 9 and self.button_type == 1 and self.value == 1


### PR DESCRIPTION
I had to change the event definitions for my controller (Model CUH-ZCT2E). I saw that it's possible to overwrite the event definition. Maybe there should be some default event definitions for different controller models?!